### PR TITLE
Per VRF or Prefix specific settings

### DIFF
--- a/README.dnsmasq.dhcp.md
+++ b/README.dnsmasq.dhcp.md
@@ -17,10 +17,10 @@ From the prefixes, the associated VRF is retrieved and at which Site it is opera
 The name of the VRF and the name of the vlan will be concattenated and result into the name of the DHCP scope. The default gateway and DNS server is configured. The prefix will be configured with a DHCP range based on the `--dhcp-host-range-offset-min` and `--dhcp-host-range-offset-max` parameters, with a default lease time from the `--dhcp-default-lease-time-range` parameters.
 
 #### Default gateway selection
-Based on the VRF assessed, the first IP address with the tag `net_default_gateway` will be selected as the default gateway.
+Based on the VRF assessed, the first IP address with the tag `net_default_gateway` will be selected as the default gateway. Unless, overridden in a matching `[prefix:<cidr>]` section from the configuration file with a `gateway = <ip addr>`.
 
 #### DNS server selection
-The IP address of the default gateway will retrieved. The DNS server field associated to the IP address is retrieved and used as the DNS server.
+The IP address of the default gateway will retrieved. The DNS server field associated to the IP address is retrieved and used as the DNS server. Unless, overridden in a matching `[prefix:<cidr>]` section from the configuration file with a `dns = <ip addr>`.
 
 
 ### DHCP example output
@@ -115,6 +115,11 @@ boot_servername = netboot.xyz
 boot_address = 192.168.123.45
 
 override_dns_server = 192.168.1.3
+
+[prefix:192.168.200.0/24]
+gateway = 192.168.200.55
+dns = 192.168.200.66
+ntp = 192.168.200.77
 ```
 
 ## Example script to mash it all up

--- a/dnsmasq/configuration.py
+++ b/dnsmasq/configuration.py
@@ -185,6 +185,22 @@ def parse_config_section(ctx, config, section):
     return ctx
 
 
+# Look for all [prefix:<cidr>]
+def parse_config_prefixes(ctx, config):
+    # init prefixes overrides
+    ctx['prefixes'] = {}
+
+    # Dynamically load prefix information into the ctx
+    for section in config.sections():
+        if section.startswith("prefix:"):
+            prefix = section.split(":")[1] 
+            ctx['prefixes'][prefix] = {}
+            for key in config[section]:
+                ctx['prefixes'][prefix][key] = config[section][key]
+
+    return ctx
+
+
 def parse_config(ctx):
     config = configparser.ConfigParser()
 
@@ -196,6 +212,7 @@ def parse_config(ctx):
 
     ctx = parse_config_section(ctx, config, 'generic')
     ctx = parse_config_section(ctx, config, 'dnsmasq_dhcp')
+    ctx = parse_config_prefixes(ctx, config)
 
     return ctx
 

--- a/netbox-2-dnsmasq-dhcp.py
+++ b/netbox-2-dnsmasq-dhcp.py
@@ -25,12 +25,26 @@ def netbox_generate_dnsmasq_dhcp_section_header_info(prefix_obj, dnsmasq_dhcp_se
     return dnsmasq_dhcp_section
 
 
-# Get default gateway from the VRF based on a tag
+# Get default gateway
 def netbox_process_prefix_into_dnsmasq_dhcp_section_gateway(ctx, prefix_obj, dnsmasq_dhcp_section) -> DNSMasq_DHCP_Section:
+    # Check if there is a specific prefix with gateway in the config file
+    if 'prefixes' in ctx and \
+        prefix_obj['prefix'] in ctx['prefixes'] and \
+        'gateway' in ctx['prefixes'][prefix_obj['prefix']]:
+
+        # Record the default gateway
+        dnsmasq_dhcp_section.append_dhcp_option(
+                DNSMasq_DHCP_Option(
+                    netboxers_queries.get_vrf_vlan_name_from_prefix_obj(prefix_obj),
+                    "3", ctx['prefixes'][prefix_obj['prefix']]['gateway']))
+        return dnsmasq_dhcp_section
+
+    ## Resort to old behavior: Get default gateway from the VRF based on a tag
     default_gateway_ip_addr_obj = netboxers_queries.get_net_default_gateway_from_vrf(ctx, prefix_obj['vrf']['id'])
     if default_gateway_ip_addr_obj is None:
         return None
 
+    # Cut and split cidr to addr
     default_gateway_ip_addr = \
         ipaddress.ip_address(default_gateway_ip_addr_obj['address'].split("/")[0])
 
@@ -42,13 +56,49 @@ def netbox_process_prefix_into_dnsmasq_dhcp_section_gateway(ctx, prefix_obj, dns
                     netboxers_queries.get_vrf_vlan_name_from_prefix_obj(prefix_obj),
                     "3", default_gateway_ip_addr))
 
-        # Override from config or args, or fetch the config from netbox
-        if 'dnsmasq_dhcp_override_dns_server' in ctx and ctx['dnsmasq_dhcp_override_dns_server'] is not None:
-            default_dnsname_ip_addr = ctx['dnsmasq_dhcp_override_dns_server']
-        else:
-            # Get DNS from the default gateway record
-            default_dnsname_ip_addr = netboxers_queries.get_dns_host_from_ip_address(ctx, \
-                default_gateway_ip_addr_obj)
+    return dnsmasq_dhcp_section
+
+
+# Get default gateway from the VRF based on a tag
+def netbox_process_prefix_into_dnsmasq_dhcp_section_dns(ctx, prefix_obj, dnsmasq_dhcp_section) -> DNSMasq_DHCP_Section:
+    # Override from config or args, or fetch the config from netbox
+    if 'dnsmasq_dhcp_override_dns_server' in ctx and ctx['dnsmasq_dhcp_override_dns_server'] is not None:
+        default_dnsname_ip_addr = ctx['dnsmasq_dhcp_override_dns_server']
+
+        dnsmasq_dhcp_section.append_dhcp_option(
+                DNSMasq_DHCP_Option(
+                    netboxers_queries.get_vrf_vlan_name_from_prefix_obj(prefix_obj),
+                    "6", default_dnsname_ip_addr))
+
+        return dnsmasq_dhcp_section
+
+    # Check if there is a specific prefix with gateway in the config file for its prefix
+    if 'prefixes' in ctx and prefix_obj['prefix'] in ctx['prefixes'] and \
+        'dns' in ctx['prefixes'][prefix_obj['prefix']]:
+
+        # Record the default gateway
+        dnsmasq_dhcp_section.append_dhcp_option(
+                DNSMasq_DHCP_Option(
+                    netboxers_queries.get_vrf_vlan_name_from_prefix_obj(prefix_obj),
+                    "6", ctx['prefixes'][prefix_obj['prefix']]['dns']))
+
+        return dnsmasq_dhcp_section
+
+    ### Resort to the old behavior, fetch the gateway address, and from the
+    ### gateway address fetch its associated DNS server
+    default_gateway_ip_addr_obj = netboxers_queries.get_net_default_gateway_from_vrf(ctx, prefix_obj['vrf']['id'])
+    if default_gateway_ip_addr_obj is None:
+        return None
+
+    # Cut and split cidr to addr
+    default_gateway_ip_addr = \
+        ipaddress.ip_address(default_gateway_ip_addr_obj['address'].split("/")[0])
+
+    # Write default gateway
+    if default_gateway_ip_addr is not None:
+        # Get DNS from the default gateway record
+        default_dnsname_ip_addr = netboxers_queries.get_dns_host_from_ip_address(ctx, \
+            default_gateway_ip_addr_obj)
 
         # Write DNS server
         if default_dnsname_ip_addr is not None:
@@ -62,7 +112,20 @@ def netbox_process_prefix_into_dnsmasq_dhcp_section_gateway(ctx, prefix_obj, dns
     return dnsmasq_dhcp_section
 
 
+# Get default gateway from the configuration file
 def netbox_process_prefix_into_dnsmasq_dhcp_section_ntp(ctx, prefix_obj, dnsmasq_dhcp_section) -> DNSMasq_DHCP_Section:
+    # Check if there is a specific prefix with gateway in the config file for its prefix
+    if 'prefixes' in ctx and prefix_obj['prefix'] in ctx['prefixes'] and \
+        'ntp' in ctx['prefixes'][prefix_obj['prefix']]:
+
+        # Record the default gateway
+        dnsmasq_dhcp_section.append_dhcp_option(
+                DNSMasq_DHCP_Option(
+                    netboxers_queries.get_vrf_vlan_name_from_prefix_obj(prefix_obj),
+                    "42", ctx['prefixes'][prefix_obj['prefix']]['ntp']))
+
+        return dnsmasq_dhcp_section
+
     # Write default NTP server
     if 'dnsmasq_dhcp_default_ntp_server' in ctx and ctx['dnsmasq_dhcp_default_ntp_server'] is not None:
         dnsmasq_dhcp_section.append_dhcp_option(
@@ -116,8 +179,11 @@ def netbox_process_prefix_into_dnsmasq_dhcp_section(ctx, prefix_obj) -> DNSMasq_
     # Generate DNSMasq DHCP Section header information
     dnsmasq_dhcp_section = netbox_generate_dnsmasq_dhcp_section_header_info(prefix_obj, dnsmasq_dhcp_section)
 
-    # Get default gateway from the VRF based on a tag
+    # Get default gateway gateway
     dnsmasq_dhcp_section = netbox_process_prefix_into_dnsmasq_dhcp_section_gateway(ctx, prefix_obj, dnsmasq_dhcp_section)
+
+    # Get DNS server config
+    dnsmasq_dhcp_section = netbox_process_prefix_into_dnsmasq_dhcp_section_dns(ctx, prefix_obj, dnsmasq_dhcp_section)
 
     # Add NTP server config
     dnsmasq_dhcp_section = netbox_process_prefix_into_dnsmasq_dhcp_section_ntp(ctx, prefix_obj, dnsmasq_dhcp_section)

--- a/netbox-2-dnsmasq-dhcp.py
+++ b/netbox-2-dnsmasq-dhcp.py
@@ -25,7 +25,7 @@ def netbox_generate_dnsmasq_dhcp_section_header_info(prefix_obj, dnsmasq_dhcp_se
     return dnsmasq_dhcp_section
 
 
-# Get default gateway
+# Get default gateway for the prefix
 def netbox_process_prefix_into_dnsmasq_dhcp_section_gateway(ctx, prefix_obj, dnsmasq_dhcp_section) -> DNSMasq_DHCP_Section:
     # Check if there is a specific prefix with gateway in the config file
     if 'prefixes' in ctx and \
@@ -59,12 +59,13 @@ def netbox_process_prefix_into_dnsmasq_dhcp_section_gateway(ctx, prefix_obj, dns
     return dnsmasq_dhcp_section
 
 
-# Get default gateway from the VRF based on a tag
+# Get DNS server configuration for the prefix
 def netbox_process_prefix_into_dnsmasq_dhcp_section_dns(ctx, prefix_obj, dnsmasq_dhcp_section) -> DNSMasq_DHCP_Section:
     # Override from config or args, or fetch the config from netbox
     if 'dnsmasq_dhcp_override_dns_server' in ctx and ctx['dnsmasq_dhcp_override_dns_server'] is not None:
         default_dnsname_ip_addr = ctx['dnsmasq_dhcp_override_dns_server']
 
+        # Record the DNS server
         dnsmasq_dhcp_section.append_dhcp_option(
                 DNSMasq_DHCP_Option(
                     netboxers_queries.get_vrf_vlan_name_from_prefix_obj(prefix_obj),
@@ -72,11 +73,11 @@ def netbox_process_prefix_into_dnsmasq_dhcp_section_dns(ctx, prefix_obj, dnsmasq
 
         return dnsmasq_dhcp_section
 
-    # Check if there is a specific prefix with gateway in the config file for its prefix
+    # Check if there is a specific prefix with dns in the config file for its prefix
     if 'prefixes' in ctx and prefix_obj['prefix'] in ctx['prefixes'] and \
         'dns' in ctx['prefixes'][prefix_obj['prefix']]:
 
-        # Record the default gateway
+        # Record the DNS server
         dnsmasq_dhcp_section.append_dhcp_option(
                 DNSMasq_DHCP_Option(
                     netboxers_queries.get_vrf_vlan_name_from_prefix_obj(prefix_obj),
@@ -94,7 +95,7 @@ def netbox_process_prefix_into_dnsmasq_dhcp_section_dns(ctx, prefix_obj, dnsmasq
     default_gateway_ip_addr = \
         ipaddress.ip_address(default_gateway_ip_addr_obj['address'].split("/")[0])
 
-    # Write default gateway
+    # Write DNS server based on gateway information
     if default_gateway_ip_addr is not None:
         # Get DNS from the default gateway record
         default_dnsname_ip_addr = netboxers_queries.get_dns_host_from_ip_address(ctx, \
@@ -102,7 +103,7 @@ def netbox_process_prefix_into_dnsmasq_dhcp_section_dns(ctx, prefix_obj, dnsmasq
 
         # Write DNS server
         if default_dnsname_ip_addr is not None:
-            # Record the default gateway
+            # Record the DNS server
             ## Recording scope, option and value
             dnsmasq_dhcp_section.append_dhcp_option(
                     DNSMasq_DHCP_Option(
@@ -112,13 +113,13 @@ def netbox_process_prefix_into_dnsmasq_dhcp_section_dns(ctx, prefix_obj, dnsmasq
     return dnsmasq_dhcp_section
 
 
-# Get default gateway from the configuration file
+# Get ntp from the configuration file for the prefix
 def netbox_process_prefix_into_dnsmasq_dhcp_section_ntp(ctx, prefix_obj, dnsmasq_dhcp_section) -> DNSMasq_DHCP_Section:
-    # Check if there is a specific prefix with gateway in the config file for its prefix
+    # Check if there is a specific prefix with ntp in the config file for its prefix
     if 'prefixes' in ctx and prefix_obj['prefix'] in ctx['prefixes'] and \
         'ntp' in ctx['prefixes'][prefix_obj['prefix']]:
 
-        # Record the default gateway
+        # Record the ntp server
         dnsmasq_dhcp_section.append_dhcp_option(
                 DNSMasq_DHCP_Option(
                     netboxers_queries.get_vrf_vlan_name_from_prefix_obj(prefix_obj),
@@ -126,7 +127,7 @@ def netbox_process_prefix_into_dnsmasq_dhcp_section_ntp(ctx, prefix_obj, dnsmasq
 
         return dnsmasq_dhcp_section
 
-    # Write default NTP server
+    # Write NTP server
     if 'dnsmasq_dhcp_default_ntp_server' in ctx and ctx['dnsmasq_dhcp_default_ntp_server'] is not None:
         dnsmasq_dhcp_section.append_dhcp_option(
                 DNSMasq_DHCP_Option(

--- a/netbox.config.example
+++ b/netbox.config.example
@@ -27,3 +27,8 @@ zonefile = /tmp/zonefile
 zonefile_in_addr = /tmp/zonefile_in_addr
 domain = koeroo.lan
 zonefile_footer = zonefile.footer.example
+
+[prefix:192.168.200.0/24]
+gateway = 192.168.200.1
+dns = 192.168.200.2
+ntp = 192.168.200.1


### PR DESCRIPTION
This feature adds support to override per prefix settings from the configuration file. The config file is dynamically loaded into memory and when config info matches incoming info from netbox, the configuration file takes precedence.